### PR TITLE
Update sensor.py

### DIFF
--- a/custom_components/resrobot/sensor.py
+++ b/custom_components/resrobot/sensor.py
@@ -16,7 +16,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.components.rest.sensor import RestData
+
 from homeassistant.const import (CONF_NAME)
 from dateutil import parser
 from datetime import datetime


### PR DESCRIPTION
Removed from import RestData
This import has changed in Home Assistant, and with block the integration from starting on > 2021.3.0.
Since it was not used, it need to be removed in this PR.